### PR TITLE
AI-180: Fix statistical imputation - use mode() for categorical and median() for numerical

### DIFF
--- a/interest_repaid_derived.py
+++ b/interest_repaid_derived.py
@@ -53,6 +53,23 @@ def remove_columns_with_missing_values(df, missing_threshold=0):
         print(f"Columns removed due to missing values: {columns_to_remove}")
     return df.drop(columns=columns_to_remove)
 
+def impute_missing_values(df, categorical_columns, numerical_columns):
+
+    """
+    Impute missing values using appropriate strategies:
+    - mode() for categorical features (avoids invalid fractional values)
+    - median() for numerical features (robust to outliers)
+    """
+    for col in categorical_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna(df[col].mode()[0])
+    
+    for col in numerical_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna(df[col].median())
+    
+    return df
+
 def clean_data(filepath):
     df = load_data(filepath)
     
@@ -141,8 +158,8 @@ other_columns_not_encoded = ['has_mobile_no','validatedon_userid','loan_transact
 df_cleaned = convert_to_categorical(df_cleaned, categorical_columns)
 df_cleaned = process_date_columns(df_cleaned, date_columns)
 df_cleaned = df_cleaned.drop(columns=other_columns_not_encoded)
-
-df_cleaned = remove_columns_with_missing_values(df_cleaned, missing_threshold=0)
+df_cleaned = impute_missing_values(df_cleaned, categorical_columns, numerical_columns)
+#df_cleaned = remove_columns_with_missing_values(df_cleaned, missing_threshold=0)
 
 highly_corr = ["total_costofloan_derived","total_repayment_derived","principal_repaid_derived"
 ]

--- a/nominal_interest_rate.py
+++ b/nominal_interest_rate.py
@@ -53,6 +53,22 @@ def remove_columns_with_missing_values(df, missing_threshold=0):
         print(f"Columns removed due to missing values: {columns_to_remove}")
     return df.drop(columns=columns_to_remove)
 
+def impute_missing_values(df, categorical_columns, numerical_columns):
+    """
+    Impute missing values using appropriate strategies:
+    - mode() for categorical features (avoids invalid fractional values)
+    - median() for numerical features (robust to outliers)
+    """
+    for col in categorical_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna(df[col].mode()[0])
+    
+    for col in numerical_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna(df[col].median())
+    
+    return df
+
 def clean_data(filepath):
     df = load_data(filepath)
     
@@ -143,8 +159,8 @@ other_columns_not_encoded = ['has_mobile_no','validatedon_userid','loan_transact
 df_cleaned = convert_to_categorical(df_cleaned, categorical_columns)
 df_cleaned = process_date_columns(df_cleaned, date_columns)
 df_cleaned = df_cleaned.drop(columns=other_columns_not_encoded)
-
-df_cleaned = remove_columns_with_missing_values(df_cleaned, missing_threshold=0)
+df_cleaned = impute_missing_values(df_cleaned, categorical_columns, numerical_columns)
+#df_cleaned = remove_columns_with_missing_values(df_cleaned, missing_threshold=0)
 
 highly_corr = ["interest_period_frequency_enum_2","term_frequency_10","number_of_repayments_10","activation_date","office_joining_date","date_of_birth","approvedon_date","expected_disbursedon_date","disbursedon_date","expected_maturedon_date","maturedon_date","transaction_date","submitted_on_date","annual_nominal_interest_rate","interest_charged_derived","number_of_repayments_36","term_frequency_36","principal_amount","interest_period_frequency_enum_3"]
 df_cleaned = df_cleaned.drop(columns=highly_corr)


### PR DESCRIPTION
Closes AI-180

## Problem
Missing values were being dropped entirely via 
remove_columns_with_missing_values(). This caused data loss.
Categorical features also risked invalid fractional values 
if mean() were used.

## Solution
- Added impute_missing_values() function
- mode() for categorical features (preserves valid enum values)
- median() for numerical features (robust to outliers)
- Imputation happens BEFORE one-hot encoding so original 
  column names are still accessible

## Files Changed
- interest_repaid_derived.py
- nominal_interest_rate.py